### PR TITLE
Remove `importlib` from the dependancies in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,8 +14,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-dependencies = ['importlib',
-                'matplotlib',
+dependencies = ['matplotlib',
                 'nibabel',
                 'numpy',
                 'pypulseq@git+https://github.com/tblazey/pypulseq#egg=dev',


### PR DESCRIPTION
Since `importlib` is part of the Python standard library since 3.1 (and this project requires 3.10), this shouldn't be listed as dependency.

Trying to install `importlib` through pip resulted in an error for me, and removing it fixed the installation.